### PR TITLE
Added godep package management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Go dependency workspace
+Godeps/_workspace/*

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/nopecmd/nope",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.6",
 	"Packages": [
 		"./..."
 	],

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,26 @@
+{
+	"ImportPath": "github.com/nopecmd/nope",
+	"GoVersion": "go1.5",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/flynn/go-shlex",
+			"Rev": "3f9db97f856818214da2e1057f8ad84803971cff"
+		},
+		{
+			"ImportPath": "github.com/jessevdk/go-flags",
+			"Comment": "v1-334-g6b9493b",
+			"Rev": "6b9493b3cb60367edd942144879646604089e3f7"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/go-ps",
+			"Rev": "e6c6068076470196af082b1ff896e24a51a87b2a"
+		},
+		{
+			"ImportPath": "github.com/rogpeppe/rog-go/reverse",
+			"Rev": "f57ad5e24ab7813942c045f86eda1066eb969e98"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 ### Coding convention/style guide
 
 Follow https://github.com/golang/go/wiki/CodeReviewComments.
+
+### Using godep
+
+- Godep needs to be installed by running `go install github.com/tools/godep`
+- Run `godep go install` to install the package
+- Run `godep save ./...` when adding a new dependency
+
+More info at https://godoc.org/github.com/tools/godep


### PR DESCRIPTION
https://godoc.org/github.com/tools/godep

TL;DR:
- Install `godep`
- Use `godep go install` instead of `go install`
- After using `go get`, save the dependency by using `godep save ./...`
